### PR TITLE
Somewhat proper standalone timer implementation

### DIFF
--- a/SoulSplitter.sln
+++ b/SoulSplitter.sln
@@ -48,6 +48,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoulMemory.Tests", "tests\S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoulSplitter.Tests", "tests\SoulSplitter.Tests\SoulSplitter.Tests.csproj", "{13D6FF7F-E774-424C-940C-C76FF98D8916}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "clitimer", "src\clitimer\clitimer.csproj", "{F7482938-4DEE-4BEB-BBA7-D9AE696404F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -74,6 +76,10 @@ Global
 		{13D6FF7F-E774-424C-940C-C76FF98D8916}.Debug|x64.Build.0 = Debug|x64
 		{13D6FF7F-E774-424C-940C-C76FF98D8916}.Release|x64.ActiveCfg = Release|x64
 		{13D6FF7F-E774-424C-940C-C76FF98D8916}.Release|x64.Build.0 = Release|x64
+		{F7482938-4DEE-4BEB-BBA7-D9AE696404F3}.Debug|x64.ActiveCfg = Debug|x64
+		{F7482938-4DEE-4BEB-BBA7-D9AE696404F3}.Debug|x64.Build.0 = Debug|x64
+		{F7482938-4DEE-4BEB-BBA7-D9AE696404F3}.Release|x64.ActiveCfg = Release|x64
+		{F7482938-4DEE-4BEB-BBA7-D9AE696404F3}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -84,6 +90,7 @@ Global
 		{A30986D1-6B5A-415D-A737-AE0D9EF4CE9C} = {DAF9C4D1-2E17-44C9-BC7B-0F26EDBE97E2}
 		{A8FE4ABB-A952-49B0-B39A-9B3B4574587B} = {FCB71284-721B-4845-AF63-F80DD168D949}
 		{13D6FF7F-E774-424C-940C-C76FF98D8916} = {FCB71284-721B-4845-AF63-F80DD168D949}
+		{F7482938-4DEE-4BEB-BBA7-D9AE696404F3} = {DAF9C4D1-2E17-44C9-BC7B-0F26EDBE97E2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C356BE2C-9585-4CCF-A852-29C6DFCCD5A5}

--- a/src/cli/Program.cs
+++ b/src/cli/Program.cs
@@ -344,62 +344,6 @@ namespace cli
 
         #endregion
 
-        #region stand alone bs removal for ER
-        private static void StandAloneErBlackscreenRemoval()
-        {
-            Console.CursorVisible = false;
-            int _inGameTime = 0;
-            var _eldenRing = new EldenRing();
-            while (true)
-            {
-                //Refresh, display errors if there are any
-
-                var result = _eldenRing.TryRefresh();
-                if (result.IsErr)
-                {
-                    var err = result.GetErr();
-                    Console.Clear();
-                    Console.WriteLine(err.ToString());
-                    Console.Out.Flush();
-                    Thread.Sleep(3000);
-                    Console.Clear();
-                    continue;
-                }
-
-                //
-                var currentIgt = _eldenRing.GetInGameTimeMilliseconds();
-                var blackscreenActive = _eldenRing.IsBlackscreenActive();
-
-
-                //Blackscreens/meme loading screens - timer is running, but game is actually loading
-                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
-                {
-                    //Trace.WriteLine($"Writing IGT: {TimeSpan.FromMilliseconds(_inGameTime)}");
-                    _eldenRing.WriteInGameTimeMilliseconds(_inGameTime);
-                }
-                else
-                {
-                    if (currentIgt != 0)
-                    {
-                        _inGameTime = currentIgt;
-                    }
-                }
-
-                if (_inGameTime == 0)
-                {
-                    Console.SetCursorPosition(0, 1);
-                    Console.WriteLine("                                       ");
-                }
-
-                Console.SetCursorPosition(0, 1);
-                Console.WriteLine(TimeSpan.FromMilliseconds(_inGameTime).ToString(@"hh\:mm\:ss\.fff"));
-
-                Thread.Sleep(16);
-            }
-        }
-
-        #endregion
-
         #region Param generation
 
         private static void GenerateParams()

--- a/src/clitimer/Program.cs
+++ b/src/clitimer/Program.cs
@@ -1,0 +1,346 @@
+﻿// This file is part of the SoulSplitter distribution (https://github.com/FrankvdStam/SoulSplitter).
+// Copyright (c) 2022 Frank van der Stam.
+// https://github.com/FrankvdStam/SoulSplitter/blob/main/LICENSE
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Threading;
+using SoulMemory.DarkSouls1;
+using SoulMemory.DarkSouls2;
+using SoulMemory.DarkSouls3;
+using SoulMemory.Sekiro;
+using SoulMemory.EldenRing;
+
+#pragma warning disable CS0162
+
+namespace clitimer
+{
+    internal class Program
+    {
+        [STAThread]
+        static void Main(string[] args)
+        {
+            // Re-enable the cursor and move down a line on CTRL + C, in order to properly clean up timer stuff
+            Console.CancelKeyPress += (object sender, ConsoleCancelEventArgs e) =>
+            {
+                Console.CursorVisible = true;
+                Console.SetCursorPosition(0, Console.CursorTop + 1);
+            };
+
+            // Prompt the user for which game to use the timer on
+            Console.Write("[1] Dark Souls 1\n[2] Dark Souls 2\n[3] Dark Souls 3\n[S] Sekiro\n[E] Elden Ring\nSelect game: ");
+            var sel = Console.Read();
+
+            // Not the prettiest, but whatever, merging all of them probably wouldn't have been much nicer
+            switch (Convert.ToChar(sel))
+            {
+                case '1':
+                    ds1Timer();
+                    break;
+                case '2':
+                    ds2Timer();
+                    break;
+                case '3':
+                    ds3Timer();
+                    break;
+                case 'E':
+                case 'e':
+                    eldenringTimer();
+                    break;
+                case 'S':
+                case 's':
+                    sekiroTimer();
+                    break;
+            }
+
+            // Generic error message because why not
+            Console.WriteLine("Unknown or unimplemented. Exiting..");
+
+            return;
+        }
+
+        private static void ds1Timer()
+        {
+            // Set the cursor invisible, because we don't want to see it over the timer
+            Console.CursorVisible = false;
+
+            // Prep
+            int _inGameTime = 0;
+            var _ds1 = new DarkSouls1();
+            bool hadError = false;
+
+            // Timer loop, refreshes roughly every frame @ 60 FPS
+            // Prints the current time or error and immediately moves back a line (or multiple at least for longer errors)
+            // Resizing the terminal while it's running might not work well
+            while (true)
+            {
+                // Refresh, display errors if there are any
+                var result = _ds1.TryRefresh();
+                if (result.IsErr)
+                {
+                    var err = result.GetErr();
+                    Console.WriteLine(err.ToString());
+                    Console.SetCursorPosition(0, Console.CursorTop - (int)Math.Ceiling((float)err.ToString().Length / (float)Console.WindowWidth));
+                    hadError = true;
+                    continue;
+                }
+                else if (hadError)
+                {
+                    Console.Write(new String(' ', Console.BufferWidth));
+                    Console.SetCursorPosition(0, Console.CursorTop - 1);
+                    hadError = false;
+                }
+
+                // Get ingame time
+                var currentIgt = _ds1.GetInGameTimeMilliseconds();
+                if (currentIgt != 0)
+                {
+                    _inGameTime = currentIgt;
+                }
+
+                // Finally format the current time and output it
+                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
+                Console.SetCursorPosition(0, Console.CursorTop - 1);
+
+                Thread.Sleep(16);
+            }
+        }
+
+        private static void ds2Timer()
+        {
+            // Set the cursor invisible, because we don't want to see it over the timer
+            Console.CursorVisible = false;
+
+            // Prep
+            int _inGameTime = 0;
+            var _ds2 = new DarkSouls2();
+            bool hadError = false;
+
+            // Timer loop, refreshes roughly every frame @ 60 FPS
+            // Prints the current time or error and immediately moves back a line (or multiple at least for longer errors)
+            // Resizing the terminal while it's running might not work well
+            while (true)
+            {
+                // Refresh, display errors if there are any
+                var result = _ds2.TryRefresh();
+                if (result.IsErr)
+                {
+                    var err = result.GetErr();
+                    Console.WriteLine(err.ToString());
+                    Console.SetCursorPosition(0, Console.CursorTop - (int)Math.Ceiling((float)err.ToString().Length / (float)Console.WindowWidth));
+                    hadError = true;
+                    continue;
+                }
+                else if (hadError)
+                {
+                    Console.Write(new String(' ', Console.BufferWidth));
+                    Console.SetCursorPosition(0, Console.CursorTop - 1);
+                    hadError = false;
+                }
+
+                // Get ingame time
+                var currentIgt = _ds2.GetInGameTimeMilliseconds();
+                if (currentIgt != 0)
+                {
+                    _inGameTime = currentIgt;
+                }
+
+                // Finally format the current time and output it
+                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
+                Console.SetCursorPosition(0, Console.CursorTop - 1);
+
+                Thread.Sleep(16);
+            }
+        }
+
+        private static void ds3Timer()
+        {
+            // Set the cursor invisible, because we don't want to see it over the timer
+            Console.CursorVisible = false;
+
+            // Prep
+            int _inGameTime = 0;
+            var _ds3 = new DarkSouls3();
+            bool hadError = false;
+
+            // Timer loop, refreshes roughly every frame @ 60 FPS
+            // Prints the current time or error and immediately moves back a line (or multiple at least for longer errors)
+            // Resizing the terminal while it's running might not work well
+            while (true)
+            {
+                // Refresh, display errors if there are any
+                var result = _ds3.TryRefresh();
+                if (result.IsErr)
+                {
+                    var err = result.GetErr();
+                    Console.WriteLine(err.ToString());
+                    Console.SetCursorPosition(0, Console.CursorTop - (int)Math.Ceiling((float)err.ToString().Length / (float)Console.WindowWidth));
+                    hadError = true;
+                    continue;
+                }
+                else if (hadError)
+                {
+                    Console.Write(new String(' ', Console.BufferWidth));
+                    Console.SetCursorPosition(0, Console.CursorTop - 1);
+                    hadError = false;
+                }
+
+                // Get ingame time and blackscreen state
+                var currentIgt = _ds3.GetInGameTimeMilliseconds();
+                var blackscreenActive = _ds3.BlackscreenActive();
+
+                // Blackscreens / meme loading screens - timer is running, but game is actually loading
+                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
+                {
+                    _ds3.WriteInGameTimeMilliseconds(_inGameTime);
+                }
+                else
+                {
+                    if (currentIgt != 0)
+                    {
+                        _inGameTime = currentIgt;
+                    }
+                }
+
+                // Finally format the current time and output it
+                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
+                Console.SetCursorPosition(0, Console.CursorTop - 1);
+
+                Thread.Sleep(16);
+            }
+        }
+
+        private static void sekiroTimer()
+        {
+            // Set the cursor invisible, because we don't want to see it over the timer
+            Console.CursorVisible = false;
+
+            // Prep
+            int _inGameTime = 0;
+            var _sekiro = new Sekiro();
+            bool hadError = false;
+
+            // Timer loop, refreshes roughly every frame @ 60 FPS
+            // Prints the current time or error and immediately moves back a line (or multiple at least for longer errors)
+            // Resizing the terminal while it's running might not work well
+            while (true)
+            {
+                // Refresh, display errors if there are any
+                var result = _sekiro.TryRefresh();
+                if (result.IsErr)
+                {
+                    var err = result.GetErr();
+                    Console.WriteLine(err.ToString());
+                    Console.SetCursorPosition(0, Console.CursorTop - (int)Math.Ceiling((float)err.ToString().Length / (float)Console.WindowWidth));
+                    hadError = true;
+                    continue;
+                }
+                else if (hadError)
+                {
+                    Console.Write(new String(' ', Console.BufferWidth));
+                    Console.SetCursorPosition(0, Console.CursorTop - 1);
+                    hadError = false;
+                }
+
+                // Get ingame time and blackscreen state
+                var currentIgt = _sekiro.GetInGameTimeMilliseconds();
+                var blackscreenActive = _sekiro.IsBlackscreenActive();
+
+                // Blackscreens / meme loading screens - timer is running, but game is actually loading
+                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
+                {
+                    _sekiro.WriteInGameTimeMilliseconds(_inGameTime);
+                }
+                else
+                {
+                    if (currentIgt != 0)
+                    {
+                        _inGameTime = currentIgt;
+                    }
+                }
+
+                // Finally format the current time and output it
+                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
+                Console.SetCursorPosition(0, Console.CursorTop - 1);
+
+                Thread.Sleep(16);
+            }
+        }
+
+        private static void eldenringTimer()
+        {
+            // Set the cursor invisible, because we don't want to see it over the timer
+            Console.CursorVisible = false;
+
+            // Prep
+            int _inGameTime = 0;
+            var _er = new EldenRing();
+            bool hadError = false;
+
+            // Timer loop, refreshes roughly every frame @ 60 FPS
+            // Prints the current time or error and immediately moves back a line (or multiple at least for longer errors)
+            // Resizing the terminal while it's running might not work well
+            while (true)
+            {
+                // Refresh, display errors if there are any
+                var result = _er.TryRefresh();
+                if (result.IsErr)
+                {
+                    var err = result.GetErr();
+                    Console.WriteLine(err.ToString());
+                    Console.SetCursorPosition(0, Console.CursorTop - (int)Math.Ceiling((float)err.ToString().Length / (float)Console.WindowWidth));
+                    hadError = true;
+                    continue;
+                }
+                else if (hadError)
+                {
+                    Console.Write(new String(' ', Console.BufferWidth));
+                    Console.SetCursorPosition(0, Console.CursorTop - 1);
+                    hadError = false;
+                }
+
+                // Get ingame time and blackscreen state
+                var currentIgt = _er.GetInGameTimeMilliseconds();
+                var blackscreenActive = _er.IsBlackscreenActive();
+
+                // Blackscreens / meme loading screens - timer is running, but game is actually loading
+                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
+                {
+                    _er.WriteInGameTimeMilliseconds(_inGameTime);
+                }
+                else
+                {
+                    if (currentIgt != 0)
+                    {
+                        _inGameTime = currentIgt;
+                    }
+                }
+
+                // Finally format the current time and output it
+                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
+                Console.SetCursorPosition(0, Console.CursorTop - 1);
+
+                Thread.Sleep(16);
+            }
+        }
+
+    }
+}
+
+#pragma warning restore CS0162

--- a/src/clitimer/Program.cs
+++ b/src/clitimer/Program.cs
@@ -24,11 +24,10 @@ using SoulMemory.EldenRing;
 
 #pragma warning disable CS0162
 
-namespace clitimer
+namespace CliTimer
 {
     internal class Program
     {
-        [STAThread]
         static void Main(string[] args)
         {
             // Re-enable the cursor and move down a line on CTRL + C, in order to properly clean up timer stuff
@@ -76,8 +75,8 @@ namespace clitimer
             Console.CursorVisible = false;
 
             // Prep
-            int _inGameTime = 0;
-            var _ds1 = new DarkSouls1();
+            int inGameTime = 0;
+            var ds1 = new DarkSouls1();
             bool hadError = false;
 
             // Timer loop, refreshes roughly every frame @ 60 FPS
@@ -86,7 +85,7 @@ namespace clitimer
             while (true)
             {
                 // Refresh, display errors if there are any
-                var result = _ds1.TryRefresh();
+                var result = ds1.TryRefresh();
                 if (result.IsErr)
                 {
                     var err = result.GetErr();
@@ -103,14 +102,14 @@ namespace clitimer
                 }
 
                 // Get ingame time
-                var currentIgt = _ds1.GetInGameTimeMilliseconds();
+                var currentIgt = ds1.GetInGameTimeMilliseconds();
                 if (currentIgt != 0)
                 {
-                    _inGameTime = currentIgt;
+                    inGameTime = currentIgt;
                 }
 
                 // Finally format the current time and output it
-                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                TimeSpan ts = TimeSpan.FromMilliseconds(inGameTime);
                 Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
 
@@ -124,8 +123,8 @@ namespace clitimer
             Console.CursorVisible = false;
 
             // Prep
-            int _inGameTime = 0;
-            var _ds2 = new DarkSouls2();
+            int inGameTime = 0;
+            var ds2 = new DarkSouls2();
             bool hadError = false;
 
             // Timer loop, refreshes roughly every frame @ 60 FPS
@@ -134,7 +133,7 @@ namespace clitimer
             while (true)
             {
                 // Refresh, display errors if there are any
-                var result = _ds2.TryRefresh();
+                var result = ds2.TryRefresh();
                 if (result.IsErr)
                 {
                     var err = result.GetErr();
@@ -151,14 +150,14 @@ namespace clitimer
                 }
 
                 // Get ingame time
-                var currentIgt = _ds2.GetInGameTimeMilliseconds();
+                var currentIgt = ds2.GetInGameTimeMilliseconds();
                 if (currentIgt != 0)
                 {
-                    _inGameTime = currentIgt;
+                    inGameTime = currentIgt;
                 }
 
                 // Finally format the current time and output it
-                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                TimeSpan ts = TimeSpan.FromMilliseconds(inGameTime);
                 Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
 
@@ -172,8 +171,8 @@ namespace clitimer
             Console.CursorVisible = false;
 
             // Prep
-            int _inGameTime = 0;
-            var _ds3 = new DarkSouls3();
+            int inGameTime = 0;
+            var ds3 = new DarkSouls3();
             bool hadError = false;
 
             // Timer loop, refreshes roughly every frame @ 60 FPS
@@ -182,7 +181,7 @@ namespace clitimer
             while (true)
             {
                 // Refresh, display errors if there are any
-                var result = _ds3.TryRefresh();
+                var result = ds3.TryRefresh();
                 if (result.IsErr)
                 {
                     var err = result.GetErr();
@@ -199,24 +198,24 @@ namespace clitimer
                 }
 
                 // Get ingame time and blackscreen state
-                var currentIgt = _ds3.GetInGameTimeMilliseconds();
-                var blackscreenActive = _ds3.BlackscreenActive();
+                var currentIgt = ds3.GetInGameTimeMilliseconds();
+                var blackscreenActive = ds3.BlackscreenActive();
 
                 // Blackscreens / meme loading screens - timer is running, but game is actually loading
-                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
+                if (currentIgt != 0 && currentIgt > inGameTime && currentIgt < inGameTime + 1000 && blackscreenActive)
                 {
-                    _ds3.WriteInGameTimeMilliseconds(_inGameTime);
+                    ds3.WriteInGameTimeMilliseconds(inGameTime);
                 }
                 else
                 {
                     if (currentIgt != 0)
                     {
-                        _inGameTime = currentIgt;
+                        inGameTime = currentIgt;
                     }
                 }
 
                 // Finally format the current time and output it
-                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                TimeSpan ts = TimeSpan.FromMilliseconds(inGameTime);
                 Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
 
@@ -230,8 +229,8 @@ namespace clitimer
             Console.CursorVisible = false;
 
             // Prep
-            int _inGameTime = 0;
-            var _sekiro = new Sekiro();
+            int inGameTime = 0;
+            var sekiro = new Sekiro();
             bool hadError = false;
 
             // Timer loop, refreshes roughly every frame @ 60 FPS
@@ -240,7 +239,7 @@ namespace clitimer
             while (true)
             {
                 // Refresh, display errors if there are any
-                var result = _sekiro.TryRefresh();
+                var result = sekiro.TryRefresh();
                 if (result.IsErr)
                 {
                     var err = result.GetErr();
@@ -257,24 +256,24 @@ namespace clitimer
                 }
 
                 // Get ingame time and blackscreen state
-                var currentIgt = _sekiro.GetInGameTimeMilliseconds();
-                var blackscreenActive = _sekiro.IsBlackscreenActive();
+                var currentIgt = sekiro.GetInGameTimeMilliseconds();
+                var blackscreenActive = sekiro.IsBlackscreenActive();
 
                 // Blackscreens / meme loading screens - timer is running, but game is actually loading
-                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
+                if (currentIgt != 0 && currentIgt > inGameTime && currentIgt < inGameTime + 1000 && blackscreenActive)
                 {
-                    _sekiro.WriteInGameTimeMilliseconds(_inGameTime);
+                    sekiro.WriteInGameTimeMilliseconds(inGameTime);
                 }
                 else
                 {
                     if (currentIgt != 0)
                     {
-                        _inGameTime = currentIgt;
+                        inGameTime = currentIgt;
                     }
                 }
 
                 // Finally format the current time and output it
-                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                TimeSpan ts = TimeSpan.FromMilliseconds(inGameTime);
                 Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
 
@@ -288,8 +287,8 @@ namespace clitimer
             Console.CursorVisible = false;
 
             // Prep
-            int _inGameTime = 0;
-            var _er = new EldenRing();
+            int inGameTime = 0;
+            var er = new EldenRing();
             bool hadError = false;
 
             // Timer loop, refreshes roughly every frame @ 60 FPS
@@ -298,7 +297,7 @@ namespace clitimer
             while (true)
             {
                 // Refresh, display errors if there are any
-                var result = _er.TryRefresh();
+                var result = er.TryRefresh();
                 if (result.IsErr)
                 {
                     var err = result.GetErr();
@@ -315,24 +314,24 @@ namespace clitimer
                 }
 
                 // Get ingame time and blackscreen state
-                var currentIgt = _er.GetInGameTimeMilliseconds();
-                var blackscreenActive = _er.IsBlackscreenActive();
+                var currentIgt = er.GetInGameTimeMilliseconds();
+                var blackscreenActive = er.IsBlackscreenActive();
 
                 // Blackscreens / meme loading screens - timer is running, but game is actually loading
-                if (currentIgt != 0 && currentIgt > _inGameTime && currentIgt < _inGameTime + 1000 && blackscreenActive)
+                if (currentIgt != 0 && currentIgt > inGameTime && currentIgt < inGameTime + 1000 && blackscreenActive)
                 {
-                    _er.WriteInGameTimeMilliseconds(_inGameTime);
+                    er.WriteInGameTimeMilliseconds(inGameTime);
                 }
                 else
                 {
                     if (currentIgt != 0)
                     {
-                        _inGameTime = currentIgt;
+                        inGameTime = currentIgt;
                     }
                 }
 
                 // Finally format the current time and output it
-                TimeSpan ts = TimeSpan.FromMilliseconds(_inGameTime);
+                TimeSpan ts = TimeSpan.FromMilliseconds(inGameTime);
                 Console.WriteLine($"{(int)ts.TotalHours:D2}" + ts.ToString(@"\:mm\:ss\.fff"));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
 

--- a/src/clitimer/clitimer.csproj
+++ b/src/clitimer/clitimer.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+    <PropertyGroup>
+		<OutputType>Exe</OutputType>
+        <TargetFramework>net481</TargetFramework>
+        <PlatformTarget>x64</PlatformTarget>
+		<Platforms>x64</Platforms>
+        <UseWPF>false</UseWPF>
+		<Title>clitimer</Title>
+		<PackageProjectUrl>https://github.com/FrankvdStam/SoulSplitter</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/FrankvdStam/SoulSplitter</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>Dark Souls; Dark Souls 2; Dark Souls 3; Sekiro; Sekiro: Shadows Die Twice; Elden Ring; Armored Core 6;</PackageTags>
+        <PackageReadmeFile>../../README.md</PackageReadmeFile>
+        <PackageLicenseFile>../../LICENSE</PackageLicenseFile>
+        <Copyright>(c) 2022 by Frank van der Stam, GPL-v3 licensed</Copyright>
+        <SonarQubeExclude>true</SonarQubeExclude>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\SoulMemory\SoulMemory.csproj" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
This PR moves the standalone ER cli timer + blackscreen remover to a separate executable, while also adding support for DS 1-3 and Sekiro.

On start, it prompts the user for the game, after which it displays the timer (or error message) underneath it. Due to this, it also doesn't clear the entire console window anymore each time it updates, and instead updates the same line. In some cases, resizing the window too much might not work super well, but it generally behaved well on both Windows and Linux in my testing.

I also noticed that the time formatting in the previous code sticked to a 24 hour time format, after which it would loop around, which I fixed.

The use case for this is mostly Linux users speedrunning via Wine/Proton, since LiveSplit tends to be wonky there.