### PR TITLE
fix version check for game v1.10.x

### DIFF
--- a/src/SoulMemory/EldenRing/EldenRing.cs
+++ b/src/SoulMemory/EldenRing/EldenRing.cs
@@ -241,6 +241,8 @@ namespace SoulMemory.EldenRing
                     {
                         default:
                             return EldenRingVersion.Unknown;
+                        case 0:
+                            return EldenRingVersion.V110;
                         case 2:
                             return EldenRingVersion.V112;
                     }


### PR DESCRIPTION
Due to this bug, game screen state check is not working for 1.10.x at present.