### PR TITLE
New ER FPS patch + Crash fix

### DIFF
--- a/src/SoulMemory/ArmoredCore6/ArmoredCore6.cs
+++ b/src/SoulMemory/ArmoredCore6/ArmoredCore6.cs
@@ -95,22 +95,16 @@ public class ArmoredCore6 : IGame
 
     private ResultErr<RefreshError> InjectMods()
     {
-        Exception? exception = null;
         try
         {
-            soulmods.Soulmods.Inject(GetProcess()!);
+            if (soulmods.Soulmods.Inject(GetProcess()!).IsErr)
+            {
+                return Result.Err(new RefreshError(RefreshErrorReason.ModLoadFailed));
+            }
         }
-        catch (Exception e) { exception = e; }
-
-        var module = _armoredCore6.ProcessWrapper.GetProcessModules().Find(i => i.ModuleName == (_armoredCore6.ProcessWrapper.Is64Bit() ? "soulmods_x64.dll" : "soulmods_x86.dll"));
-        if (module != null)
+        catch (Exception e)
         {
-            return Result.Ok();
-        }
-
-        if (exception != null)
-        {
-            return Result.Err(new RefreshError(RefreshErrorReason.ModLoadFailed, exception));
+            return Result.Err(new RefreshError(RefreshErrorReason.ModLoadFailed, e));
         }
 
         return Result.Err(new RefreshError(RefreshErrorReason.ModLoadFailed, "module not loaded"));

--- a/src/SoulMemory/ArmoredCore6/ArmoredCore6.cs
+++ b/src/SoulMemory/ArmoredCore6/ArmoredCore6.cs
@@ -102,7 +102,7 @@ public class ArmoredCore6 : IGame
         }
         catch (Exception e) { exception = e; }
 
-        var module = _armoredCore6.ProcessWrapper.GetProcessModules().Find(i => i.ModuleName == "soulmods.dll");
+        var module = _armoredCore6.ProcessWrapper.GetProcessModules().Find(i => i.ModuleName == (_armoredCore6.ProcessWrapper.Is64Bit() ? "soulmods_x64.dll" : "soulmods_x86.dll"));
         if (module != null)
         {
             return Result.Ok();

--- a/src/SoulMemory/EldenRing/EldenRing.cs
+++ b/src/SoulMemory/EldenRing/EldenRing.cs
@@ -170,22 +170,13 @@ public class EldenRing : IGame
 
             ApplyNoLogo();
 
-            if (!soulmods.Soulmods.Inject(_process!))
+            var injectResult = soulmods.Soulmods.Inject(_process!);
+            if (injectResult.IsErr)
             {
                 _igt.Clear();
-                return Result.Err(new RefreshError(RefreshErrorReason.UnknownException, "soulmods injection failed"));
+                return Result.Err(new RefreshError(RefreshErrorReason.ModLoadFailed, "soulmods injection failed"));
             }
-
-            if (_process?.GetModuleExports(_process.Is64Bit().Unwrap() ? "soulmods_x64.dll" : "soulmods_x86.dll") is Dictionary<string, long>  exports)
-            {
-                _soulmodsExports = exports;
-            } 
-            else
-            {
-                return Result.Err(new RefreshError(RefreshErrorReason.UnknownException, "Getting soulmods exports failed"));
-            }
-
-
+            _soulmodsExports = injectResult.Unwrap();
             return Result.Ok();
         }
         catch (Exception e)

--- a/src/SoulMemory/EldenRing/EldenRing.cs
+++ b/src/SoulMemory/EldenRing/EldenRing.cs
@@ -623,16 +623,16 @@ public class EldenRing : IGame
     #endregion
 
     #region soulmods
-    public bool? FpsPatchGet()
+    public bool FpsPatchGet()
     {
         if (_soulmodsExports.TryGetValue("ER_FPS_PATCH_ENABLED", out var address))
         {
-            return _process?.ReadMemory<bool>(address).Unwrap();
+            if (_process?.ReadMemory<bool>(address).Unwrap() is bool enabled)
+            {
+                return enabled;
+            }
         }
-        else
-        {
-            return null;
-        }
+        return false;
     }
 
     public void FpsPatchSet(bool b)
@@ -643,17 +643,16 @@ public class EldenRing : IGame
         }
     }
 
-
-    public float? FpsLimitGet()
+    public float FpsLimitGet()
     {
         if (_soulmodsExports.TryGetValue("ER_FPS_CUSTOM_LIMIT", out var address))
         {
-            return _process?.ReadMemory<float>(address).Unwrap();
+            if (_process?.ReadMemory<float>(address).Unwrap() is float fps)
+            {
+                return fps;
+            }
         }
-        else
-        {
-            return null;
-        }
+        return 0.0f;
     }
 
     public void FpsLimitSet(float f)

--- a/src/SoulMemory/EldenRing/EldenRing.cs
+++ b/src/SoulMemory/EldenRing/EldenRing.cs
@@ -618,10 +618,7 @@ public class EldenRing : IGame
     {
         if (_soulmodsExports.TryGetValue("ER_FPS_PATCH_ENABLED", out var address))
         {
-            if (_process?.ReadMemory<bool>(address).Unwrap() is bool enabled)
-            {
-                return enabled;
-            }
+            return _process?.ReadMemory<bool>(address).Unwrap() ?? false;
         }
         return false;
     }
@@ -638,10 +635,7 @@ public class EldenRing : IGame
     {
         if (_soulmodsExports.TryGetValue("ER_FPS_CUSTOM_LIMIT", out var address))
         {
-            if (_process?.ReadMemory<float>(address).Unwrap() is float fps)
-            {
-                return fps;
-            }
+            return _process?.ReadMemory<float>(address).Unwrap() ?? 0.0f;
         }
         return 0.0f;
     }

--- a/src/SoulMemory/Native/Kernel32.cs
+++ b/src/SoulMemory/Native/Kernel32.cs
@@ -317,7 +317,7 @@ public static class Kernel32
 
     
 
-    public static List<(string name, long address)> GetModuleExportedFunctions(this Process process, string hModuleName)
+    public static Dictionary<string, long> GetModuleExports(this Process process, string hModuleName)
     {
         var modules = process.GetModulesViaSnapshot();
         var module = modules.First(i => i.szModule.ToLowerInvariant() == hModuleName.ToLowerInvariant());
@@ -347,12 +347,12 @@ public static class Kernel32
         var ordinalTable = module.modBaseAddr.ToInt64() + exportTable.AddressOfNameOrdinals;
         var functionOffsetTable = module.modBaseAddr.ToInt64() + exportTable.AddressOfFunctions;
 
-        var functions = new List<(string name, long address)>();
+        var functions = new Dictionary<string, long>();
         for (var i = 0; i < exportTable.NumberOfNames; i++)
         {
-            var EAT = module.modBaseAddr.ToInt64() + exportTable.AddressOfFunctions;
+            var eat = module.modBaseAddr.ToInt64() + exportTable.AddressOfFunctions;
 
-            var EATPtr = (IntPtr)EAT;
+            var eatPtr = (IntPtr)eat;
 
             //Function name offset is an array of 4byte numbers
             var functionNameOffset = process.ReadMemory<uint>(nameOffsetTable + i * sizeof(uint)).Unwrap();
@@ -365,7 +365,7 @@ public static class Kernel32
             var functionOffset = process.ReadMemory<uint>(functionOffsetTable + i * sizeof(uint)).Unwrap();
             var functionAddress = module.modBaseAddr.ToInt64() + functionOffset;
 
-            functions.Add((functionName, functionAddress));
+            functions.Add(functionName, functionAddress);
         }
 
         return functions;

--- a/src/SoulMemory/Native/Kernel32.cs
+++ b/src/SoulMemory/Native/Kernel32.cs
@@ -350,10 +350,6 @@ public static class Kernel32
         var functions = new Dictionary<string, long>();
         for (var i = 0; i < exportTable.NumberOfNames; i++)
         {
-            var eat = module.modBaseAddr.ToInt64() + exportTable.AddressOfFunctions;
-
-            var eatPtr = (IntPtr)eat;
-
             //Function name offset is an array of 4byte numbers
             var functionNameOffset = process.ReadMemory<uint>(nameOffsetTable + i * sizeof(uint)).Unwrap();
             var functionName = process.ReadAsciiString(module.modBaseAddr.ToInt64() + functionNameOffset);

--- a/src/SoulMemory/soulmods/Soulmods.cs
+++ b/src/SoulMemory/soulmods/Soulmods.cs
@@ -68,11 +68,11 @@ public static class Soulmods
     
 
 
-    private static List<(string name, long address)>? _soulmodsMethods;
+    private static Dictionary<string, long>? _soulmodsExports;
     public static TSized RustCall<TSized>(this Process process, string function, TSized? parameter = null) where TSized : struct
     {
-        _soulmodsMethods ??= process.GetModuleExportedFunctions("soulmods.dll");
-        var functionPtr = _soulmodsMethods.First(i => i.name == function).address;
+        _soulmodsExports ??= process.GetModuleExports(process.Is64Bit().Unwrap() ? "soulmods_x64.dll" :"soulmods_x86.dll");
+        var functionPtr = _soulmodsExports[function];
 
         var buffer = process.Allocate(Marshal.SizeOf<TSized>());
         if (parameter.HasValue)
@@ -89,8 +89,8 @@ public static class Soulmods
     public static void GetMorphemeMessages(Process process)
     {
         //Get function address
-        var soulmods = process.GetModuleExportedFunctions("soulmods.dll");
-        var func = soulmods.First(i => i.name == "GetQueuedDarkSouls2MorphemeMessages").address;
+        var soulmods = process.GetModuleExports(process.Is64Bit().Unwrap() ? "soulmods_x64.dll" : "soulmods_x86.dll");
+        var func = soulmods["GetQueuedDarkSouls2MorphemeMessages"];
 
         //Get buffer size
         var buffer = process.Allocate(4);

--- a/src/SoulMemory/soulmods/Soulmods.cs
+++ b/src/SoulMemory/soulmods/Soulmods.cs
@@ -47,28 +47,33 @@ public class RustCallAttribute : Attribute
 
 public static class Soulmods
 {
-    public static bool Inject(Process process)
+    private static string SoulmodsModuleName(this Process process)
+    {
+        return process.Is64Bit().Unwrap() ? "soulmods_x64.dll" : "soulmods_x86.dll";
+    }
+
+    public static ResultOk<Dictionary<string, long>> Inject(Process process)
     {
         var dir = Path.GetDirectoryName(typeof(Soulmods).Assembly.Location)!;
-        var path = process.Is64Bit().Unwrap() ? Path.Combine(dir, @"soulmods_x64.dll") : Path.Combine(dir, @"soulmods_x86.dll");
+        var soulmodsModuleName = process.SoulmodsModuleName();
+        var path = Path.Combine(dir, soulmodsModuleName);
 
         process.InjectDll(path);
 
-        foreach (ProcessModule processModule in process.Modules)
+        if (process.Modules.Cast<ProcessModule>().Any(processModule => processModule.ModuleName == soulmodsModuleName))
         {
-            if (processModule.ModuleName is "soulmods_x64.dll" or "soulmods_x86.dll")
-            {
-                return true;
-            }
+            _soulmodsExports = process.GetModuleExports(soulmodsModuleName);
+            return Result.Ok(_soulmodsExports);
         }
-        return false;
+        return Result.Err();
     }
 
+    private static Dictionary<string, long>? _soulmodsExports;
+
+
+    /*
     public static MorphemeMessageBuffer GetMorphemeMessages2(Process process) => process.RustCall<MorphemeMessageBuffer>("GetQueuedDarkSouls2MorphemeMessages2");
     
-
-
-    private static Dictionary<string, long>? _soulmodsExports;
     public static TSized RustCall<TSized>(this Process process, string function, TSized? parameter = null) where TSized : struct
     {
         _soulmodsExports ??= process.GetModuleExports(process.Is64Bit().Unwrap() ? "soulmods_x64.dll" :"soulmods_x86.dll");
@@ -110,25 +115,5 @@ public static class Soulmods
             process.Free(buffer);
         }
     }
-
-    private static void OverwriteFile(string manifestResourceName, string path)
-    {
-        using var stream = typeof(Soulmods).Assembly.GetManifestResourceStream(manifestResourceName)!;
-        var buffer = new byte[stream.Length];
-        _ = stream.Read(buffer, 0, buffer.Length);
-        
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-
-        try
-        {
-            File.WriteAllBytes(path, buffer);
-
-        }
-        catch (IOException)
-        {
-            // ignore exception when overwriting existing file, may be in use by game process
-        }
-
-       
-    }
+    */
 }

--- a/src/SoulSplitter/UI/Generic/FilteredComboBox.cs
+++ b/src/SoulSplitter/UI/Generic/FilteredComboBox.cs
@@ -31,7 +31,7 @@ public class FilteredComboBox : ComboBox
 
     protected TextBox EditableTextBox => (GetTemplateChild("PART_EditableTextBox") as TextBox)!;
     
-    protected override void OnItemsSourceChanged(IEnumerable oldValue, IEnumerable newValue)
+    protected override void OnItemsSourceChanged(IEnumerable? oldValue, IEnumerable? newValue)
     {
         if (newValue != null)
         {

--- a/src/SoulSplitter/UI/Generic/FilteredComboBox.cs
+++ b/src/SoulSplitter/UI/Generic/FilteredComboBox.cs
@@ -33,12 +33,17 @@ public class FilteredComboBox : ComboBox
     
     protected override void OnItemsSourceChanged(IEnumerable oldValue, IEnumerable newValue)
     {
-        var newView = CollectionViewSource.GetDefaultView(newValue);
-        newView.Filter += FilterItem;
-    
-        var oldView = CollectionViewSource.GetDefaultView(oldValue);
-        oldView.Filter -= FilterItem;
-    
+        if (newValue != null)
+        {
+            var newView = CollectionViewSource.GetDefaultView(newValue);
+            newView.Filter += FilterItem;
+        }
+
+        if (oldValue != null)
+        {
+            var oldView = CollectionViewSource.GetDefaultView(oldValue);
+            oldView.Filter -= FilterItem;
+        }
 
         base.OnItemsSourceChanged(oldValue, newValue);
     }

--- a/src/cli/Program.cs
+++ b/src/cli/Program.cs
@@ -45,7 +45,7 @@ namespace cli
             GlobalHotKey.RegisterHotKey(ModifierKeys.Alt, Key.A, () =>{ Debug.WriteLine("A"); });
             GlobalHotKey.RegisterHotKey(ModifierKeys.Alt, Key.S, () =>{ Debug.WriteLine("S"); });
             GlobalHotKey.RegisterHotKey(ModifierKeys.Alt, Key.D, () =>{ Debug.WriteLine("D"); });
-            
+
 
             //TestUi();
             GameLoop<EldenRing>(

--- a/src/cli/Program.cs
+++ b/src/cli/Program.cs
@@ -41,7 +41,7 @@ namespace cli
         [STAThread]
         static void Main(string[] args)
         {
-
+            TestUi();
             GlobalHotKey.RegisterHotKey(ModifierKeys.Alt, Key.A, () =>{ Debug.WriteLine("A"); });
             GlobalHotKey.RegisterHotKey(ModifierKeys.Alt, Key.S, () =>{ Debug.WriteLine("S"); });
             GlobalHotKey.RegisterHotKey(ModifierKeys.Alt, Key.D, () =>{ Debug.WriteLine("D"); });

--- a/src/soulmods/src/games/x64/eldenring.rs
+++ b/src/soulmods/src/games/x64/eldenring.rs
@@ -260,7 +260,7 @@ unsafe extern "win64" fn frame_advance(registers: *mut Registers, _:usize)
     {
         ER_FRAME_RUNNING = false;
 
-        while !ER_FRAME_RUNNING {
+        while !ER_FRAME_RUNNING && ER_FRAME_ADVANCE_ENABLED {
             thread::sleep(Duration::from_micros(10));
         }
     }

--- a/src/soulmods/src/games/x64/eldenring.rs
+++ b/src/soulmods/src/games/x64/eldenring.rs
@@ -14,13 +14,57 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::{thread, time::Duration};
+
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
+
 use log::info;
+
 use crate::util::GLOBAL_VERSION;
+use crate::util::Version;
+
+struct FpsOffsets
+{
+    target_frame_delta: isize,
+    frame_delta: isize,
+    timestamp_previous: isize,
+    timestamp_current: isize,
+    timestamp_history: isize,
+}
 
 static mut IGT_BUFFER: f32 = 0.0f32;
 static mut IGT_HOOK: Option<HookPoint> = None;
+
+static mut FPS_HOOK: Option<HookPoint> = None;
+static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
+static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
+static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
+
+static mut FPS_OFFSETS: FpsOffsets = FpsOffsets {
+    target_frame_delta: 0x0,
+    frame_delta: 0x0,
+    timestamp_previous: 0x0,
+    timestamp_current: 0x0,
+    timestamp_history: 0x0,
+};
+
+#[no_mangle]
+#[used]
+pub static mut ER_FPS_PATCH_ENABLED: bool = false;
+
+#[no_mangle]
+#[used]
+pub static mut ER_FPS_CUSTOM_LIMIT: f32 = 0.0f32;
+
+#[no_mangle]
+#[used]
+pub static mut ER_FRAME_ADVANCE_ENABLED: bool = false;
+
+#[no_mangle]
+#[used]
+pub static mut ER_FRAME_RUNNING: bool = false;
+
 
 #[allow(unused_assignments)]
 pub fn init_eldenring()
@@ -28,34 +72,196 @@ pub fn init_eldenring()
     unsafe
     {
         info!("version: {}", GLOBAL_VERSION);
-
+        
+        // Get ER process
         let mut process = Process::new("eldenring.exe");
         process.refresh().unwrap();
-        let fn_increment_igt_address = process.scan_abs("increment igt", "48 c7 44 24 20 fe ff ff ff 0f 29 74 24 40 0f 28 f0 48 8b 0d ? ? ? ? 0f 28 c8 f3 0f 59 0d ? ? ? ?", 35, Vec::new()).unwrap().get_base_address();
 
+        // AoB scan for timer patch
+        let fn_increment_igt_address = process.scan_abs("increment igt", "48 c7 44 24 20 fe ff ff ff 0f 29 74 24 40 0f 28 f0 48 8b 0d ? ? ? ? 0f 28 c8 f3 0f 59 0d ? ? ? ?", 35, Vec::new()).unwrap().get_base_address();
         info!("increment IGT at 0x{:x}", fn_increment_igt_address);
 
-        unsafe extern "win64" fn increment_igt(registers: *mut Registers, _:usize)
+        // Enable timer patch
+        IGT_HOOK = Some(Hooker::new(fn_increment_igt_address, HookType::JmpBack(increment_igt), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+
+        // AoBs for FPS patches
+        let mut fps_aob = "";
+        let mut fps_history_aob = "";
+        let mut fps_custom_limit_aob = "";
+
+        // Adjust AoBs and offsets for FPS patch based on version
+        // The relevant function was adjusted slightly with the release of the DLC
+        if (GLOBAL_VERSION > Version { major: 2, minor: 0, build: 1, revision: 0 })
         {
-            let mut frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
-            //convert to milliseconds
-            frame_delta = frame_delta * 1000f32;
-            frame_delta = frame_delta * 0.96f32; //scale to IGT
+            info!("Post-DLC version detected.");
 
-            //Rather than casting, like the game does, make the behavior explicit by flooring
-            let mut floored_frame_delta = frame_delta.floor();
-            let remainder = frame_delta - floored_frame_delta;
-            IGT_BUFFER = IGT_BUFFER + remainder;
+            FPS_OFFSETS = FpsOffsets {
+                target_frame_delta: 0x1c,
+                frame_delta: 0x264,
+                timestamp_previous: 0x20,
+                timestamp_current: 0x28,
+                timestamp_history: 0x0,
+            };
 
-            if IGT_BUFFER > 1.0f32
-            {
-                IGT_BUFFER = IGT_BUFFER - 1f32;
-                floored_frame_delta += 1f32;
-            }
-            
-            (*registers).xmm1 = std::mem::transmute::<f32, u32>(floored_frame_delta) as u128;
+            fps_aob = "8b 83 64 02 00 00 89 83 b4 02 00 00";
+            fps_history_aob = "0f b6 83 74 02 00 00 89 44 cb 08";
+            fps_custom_limit_aob = "0F 57 F6 44 38 BB D0 02 00 00";
+        }
+        else
+        {
+            info!("Pre-DLC version detected.");
+
+            FPS_OFFSETS = FpsOffsets {
+                target_frame_delta: 0x20,
+                frame_delta: 0x26c,
+                timestamp_previous: 0x28,
+                timestamp_current: 0x30,
+                timestamp_history: 0x68,
+            };
+
+            fps_aob = "8b 83 6c 02 00 00 89 83 bc 02 00 00";
+            fps_history_aob = "0f b6 83 7c 02 00 00 89 44 cb 70";
+            fps_custom_limit_aob = "0F 57 F6 44 38 BB D8 02 00 00";
         }
 
-        IGT_HOOK = Some(Hooker::new(fn_increment_igt_address, HookType::JmpBack(increment_igt), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+        // AoB scan for FPS patch
+        let fn_fps_address = process.scan_abs("fps", fps_aob, 0, Vec::new()).unwrap().get_base_address();
+        info!("FPS at 0x{:x}", fn_fps_address);
+
+        // Enable FPS patch
+        FPS_HOOK = Some(Hooker::new(fn_fps_address, HookType::JmpBack(fps), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+
+        // AoB scan for FPS history patch
+        let fn_fps_history_address = process.scan_abs("fps history", fps_history_aob, 0, Vec::new()).unwrap().get_base_address();
+        info!("FPS history at 0x{:x}", fn_fps_history_address);
+
+        // Enable FPS history patch
+        FPS_HISTORY_HOOK = Some(Hooker::new(fn_fps_history_address, HookType::JmpBack(fps_history), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+
+        // AoB scan for FPS custom limit patch
+        let fn_fps_custom_limit_address = process.scan_abs("fps custom limit", fps_custom_limit_aob, 0, Vec::new()).unwrap().get_base_address();
+        info!("FPS custom limit at 0x{:x}", fn_fps_custom_limit_address);
+
+        // Enable FPS custom limit patch
+        FPS_CUSTOM_LIMIT_HOOK = Some(Hooker::new(fn_fps_custom_limit_address, HookType::JmpBack(fps_custom_limit), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+    
+
+        // AoB scan for frame advance patch
+        let fn_frame_advance_address = process.scan_abs("frame_advance", "e8 ? ? ? ? e8 ? ? ? ? 84 c0 74 4f", 21, Vec::new()).unwrap().get_base_address();
+        info!("Frame advance at 0x{:x}", fn_frame_advance_address);
+
+        // Enable frame advance patch
+        FRAME_ADVANCE_HOOK = Some(Hooker::new(fn_frame_advance_address, HookType::JmpBack(frame_advance), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+    }
+}
+
+unsafe extern "win64" fn increment_igt(registers: *mut Registers, _:usize)
+{
+    let mut frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
+    //convert to milliseconds
+    frame_delta = frame_delta * 1000f32;
+    frame_delta = frame_delta * 0.96f32; //scale to IGT
+
+    //Rather than casting, like the game does, make the behavior explicit by flooring
+    let mut floored_frame_delta = frame_delta.floor();
+    let remainder = frame_delta - floored_frame_delta;
+    IGT_BUFFER = IGT_BUFFER + remainder;
+
+    if IGT_BUFFER > 1.0f32
+    {
+        IGT_BUFFER = IGT_BUFFER - 1f32;
+        floored_frame_delta += 1f32;
+    }
+
+    (*registers).xmm1 = std::mem::transmute::<f32, u32>(floored_frame_delta) as u128;
+}
+
+// FPS patch
+// Sets the calculated frame delta to always be the target frame delta.
+// It also sets the previous frames timestamp to be the current one minus the target frame delta.
+// This makes it so the game always behaves as if it's running at the FPS limit, with slowdowns if the PC can't keep up.
+// A second patch, "FPS history" below, is required in addition to this one to ensure accuracy.
+unsafe extern "win64" fn fps(registers: *mut Registers, _:usize)
+{
+    if ER_FPS_PATCH_ENABLED
+    {
+        let ptr_flipper = (*registers).rbx as *const u8; // Flipper struct - Contains all the stuff we need
+
+        let ptr_target_frame_delta = ptr_flipper.offset(FPS_OFFSETS.target_frame_delta) as *mut f32; // Target frame delta - Set in a switch/case at the start
+        let ptr_timestamp_previous = ptr_flipper.offset(FPS_OFFSETS.timestamp_previous) as *mut u64; // Previous frames timestamp
+        let ptr_timestamp_current = ptr_flipper.offset(FPS_OFFSETS.timestamp_current) as *mut u64; // Current frames timestamp
+        let ptr_frame_delta = ptr_flipper.offset(FPS_OFFSETS.frame_delta) as *mut f32; // Current frames frame delta
+
+        // Read target frame data, the current timestamp and then calculate the timestamp diff at stable FPS
+        let target_frame_delta = std::ptr::read_volatile(ptr_target_frame_delta);
+        let timestamp_current = std::ptr::read_volatile(ptr_timestamp_current);
+        let timestamp_diff = (target_frame_delta * 10000000.0) as i32;
+
+        // Calculate the previous timestamp, as well as the frame delta
+        let timestamp_previous = timestamp_current - (timestamp_diff as u64);
+        let frame_delta = (timestamp_diff as f32) / 10000000.0;
+
+        // Write values back
+        std::ptr::write_volatile(ptr_timestamp_previous, timestamp_previous);
+        std::ptr::write_volatile(ptr_frame_delta, frame_delta);
+    }
+}
+
+// FPS history patch
+// Similar to the FPS patch, this sets the difference between the previous and current frames timestamps to the target frame delta.
+// This gets stored in an array with 32 elements, possibly for calculating FPS averages.
+unsafe extern "win64" fn fps_history(registers: *mut Registers, _:usize)
+{
+    if ER_FPS_PATCH_ENABLED
+    {
+        let ptr_flipper = (*registers).rbx as *const u8; // Flipper struct - Contains all the stuff we need
+
+        let ptr_target_frame_delta = ptr_flipper.offset(FPS_OFFSETS.target_frame_delta) as *mut f32; // Target frame delta - Set in a switch/case at the start
+        let ptr_frame_delta_history = ptr_flipper.offset((*registers).rcx as isize * 0x8 + FPS_OFFSETS.timestamp_history) as *mut u64; // Frame delta history - In an array of 32, with the index incrementing each frame
+
+        // Read the target frame delta and calculate the frame delta timestamp
+        let target_frame_delta = std::ptr::read_volatile(ptr_target_frame_delta);
+        let target_frame_delta_history = (target_frame_delta * 10000000.0) as u64;
+
+        // Write values back
+        std::ptr::write_volatile(ptr_frame_delta_history, target_frame_delta_history);
+    }
+}
+
+// FPS custom limit patch
+// This patch adjusts the target frame delta based on a custom set FPS limit.
+// It is only active while the FPS patch is enabled too, and uses the default value if it's set to 0 or less.
+// This does not allow you to go above the stock FPS limit. It is purely a QoL patch to improve glitch consistency, not an FPS unlocker.
+unsafe extern "win64" fn fps_custom_limit(registers: *mut Registers, _:usize)
+{
+    if ER_FPS_PATCH_ENABLED && ER_FPS_CUSTOM_LIMIT > 0.0f32
+    {
+        let ptr_flipper = (*registers).rbx as *const u8; // Flipper struct - Contains all the stuff we need
+
+        let ptr_target_frame_delta = ptr_flipper.offset(FPS_OFFSETS.target_frame_delta) as *mut f32; // Target frame delta - Set in a switch/case at the start
+
+        // Read the stock target frame delta and calculate the custom target frame delta
+        let target_frame_delta = std::ptr::read_volatile(ptr_target_frame_delta);
+        let custom_target_frame_delta = 1.0f32 / ER_FPS_CUSTOM_LIMIT;
+
+        // Make sure the custom target frame delta is higher than the stock one, in order to avoid going above the stock FPS limit
+        if custom_target_frame_delta > target_frame_delta
+        {
+            // Write values back
+            std::ptr::write_volatile(ptr_target_frame_delta, custom_target_frame_delta);
+        }
+    }
+}
+
+// Frame advance patch
+unsafe extern "win64" fn frame_advance(registers: *mut Registers, _:usize)
+{
+    if ER_FRAME_ADVANCE_ENABLED
+    {
+        ER_FRAME_RUNNING = false;
+
+        while !ER_FRAME_RUNNING {
+            thread::sleep(Duration::from_micros(10));
+        }
     }
 }

--- a/src/soulmods/src/util/version.rs
+++ b/src/soulmods/src/util/version.rs
@@ -2,6 +2,7 @@ use std::ffi::c_void;
 use std::fmt::{Display, Formatter};
 use std::mem::MaybeUninit;
 use std::path::PathBuf;
+use std::cmp::Ordering;
 use windows::core::PCWSTR;
 use windows::Win32::Storage::FileSystem::{GET_FILE_VERSION_INFO_FLAGS, GetFileVersionInfoExW, GetFileVersionInfoSizeW, VerQueryValueW, VS_FIXEDFILEINFO};
 
@@ -33,55 +34,114 @@ impl Version
     pub fn from_file_version_info(path: PathBuf) -> Self
     {
         unsafe
+        {
+            let mut os_str = path.into_os_string();
+            os_str.push("\0");
+
+            let str = os_str.to_string_lossy();
+
+            let mut thing: Vec<u16> = str.encode_utf16().collect();
+            let pcwstr = PCWSTR::from_raw(thing.as_mut_ptr());
+
+            let mut dwlen: u32 = 0;
+            let file_version_info_size = GetFileVersionInfoSizeW(pcwstr, Some(&mut dwlen));
+            let mut buffer: Vec<u8> = vec![0; file_version_info_size as usize];
+
+            let get_file_version_info_result = GetFileVersionInfoExW(
+                GET_FILE_VERSION_INFO_FLAGS(0x02),
+                pcwstr,
+                0,
+                file_version_info_size,
+                buffer.as_mut_ptr() as *mut c_void
+            );
+
+            if get_file_version_info_result.is_err()
             {
-                let mut os_str = path.into_os_string();
-                os_str.push("\0");
-
-                let str = os_str.to_string_lossy();
-
-                let mut thing: Vec<u16> = str.encode_utf16().collect();
-                let pcwstr = PCWSTR::from_raw(thing.as_mut_ptr());
-
-                let mut dwlen: u32 = 0;
-                let file_version_info_size = GetFileVersionInfoSizeW(pcwstr, Some(&mut dwlen));
-                let mut buffer: Vec<u8> = vec![0; file_version_info_size as usize];
-
-                let get_file_version_info_result = GetFileVersionInfoExW(
-                    GET_FILE_VERSION_INFO_FLAGS(0x02),
-                    pcwstr,
-                    0,
-                    file_version_info_size,
-                    buffer.as_mut_ptr() as *mut c_void
-                );
-
-                if get_file_version_info_result.is_err()
-                {
-                    return Version::default();
-                }
-
-                let mut pu_len = 0;
-                let mut info_ptr = MaybeUninit::<*const VS_FIXEDFILEINFO>::uninit();
-
-                let ver_query_value_w_result = VerQueryValueW(
-                    buffer.as_mut_ptr() as *const c_void,
-                    windows::core::w!("\\"),
-                    info_ptr.as_mut_ptr().cast(),
-                    &mut pu_len
-                );
-
-                if ver_query_value_w_result.0 == 0
-                {
-                    return Version::default();
-                }
-
-                let fixed_file_info = *(info_ptr.assume_init());
-
-                Version{
-                    major: (fixed_file_info.dwFileVersionMS >> 16) as u16,
-                    minor: fixed_file_info.dwFileVersionMS as u16,
-                    build: (fixed_file_info.dwFileVersionLS >> 16) as u16,
-                    revision: fixed_file_info.dwFileVersionLS as u16
-                }
+                return Version::default();
             }
+
+            let mut pu_len = 0;
+            let mut info_ptr = MaybeUninit::<*const VS_FIXEDFILEINFO>::uninit();
+
+            let ver_query_value_w_result = VerQueryValueW(
+                buffer.as_mut_ptr() as *const c_void,
+                windows::core::w!("\\"),
+                info_ptr.as_mut_ptr().cast(),
+                &mut pu_len
+            );
+
+            if ver_query_value_w_result.0 == 0
+            {
+                return Version::default();
+            }
+
+            let fixed_file_info = *(info_ptr.assume_init());
+
+            Version{
+                major: (fixed_file_info.dwFileVersionMS >> 16) as u16,
+                minor: fixed_file_info.dwFileVersionMS as u16,
+                build: (fixed_file_info.dwFileVersionLS >> 16) as u16,
+                revision: fixed_file_info.dwFileVersionLS as u16
+            }
+        }
     }
 }
+
+impl PartialEq for Version
+{
+    fn eq(&self, other: &Self) -> bool
+    {
+        if self.major == other.major && self.minor == other.minor && self.build == other.build && self.revision == other.revision
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}
+
+impl PartialOrd for Version
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering>
+    {
+        if self.major > other.major
+        {
+            return Some(Ordering::Greater);
+        }
+        else if self.major < other.major
+        {
+            return Some(Ordering::Less);
+        }
+
+        if self.minor > other.minor
+        {
+            return Some(Ordering::Greater);
+        }
+        else if self.minor < other.minor
+        {
+            return Some(Ordering::Less);
+        }
+
+        if self.build > other.build
+        {
+            return Some(Ordering::Greater);
+        }
+        else if self.build < other.build
+        {
+            return Some(Ordering::Less);
+        }
+
+        if self.revision > other.revision
+        {
+            return Some(Ordering::Greater);
+        }
+        else if self.revision < other.revision
+        {
+            return Some(Ordering::Less);
+        }
+
+        return Some(Ordering::Equal);
+    }
+} 


### PR DESCRIPTION
This adds the basics of the FPS patch for Elden Ring, as well as fixes a crash that was introduced in #73 and ensures the correct soulmods.dll files are being found.

It ports the old version of the patch to up-to-date main and changes how the values are passed between the C# and the Rust side, as I found this solution to be more reliable. In addition, it adds frame-advance capabilities for Elden Ring to soulmods, which is not used by SoulSplitter, but by SoulsTAS instead.