### PR TITLE
Fix possible crash on clicking `Reading current game position` for ER

### DIFF
--- a/src/SoulSplitter/UI/EldenRing/EldenRingViewModel.cs
+++ b/src/SoulSplitter/UI/EldenRing/EldenRingViewModel.cs
@@ -223,7 +223,7 @@ public class EldenRingViewModel : ICustomNotifyPropertyChanged
             EnabledAddSplit = _newSplitPosition != null;
         }
     }
-    private PositionViewModel? _newSplitPosition;
+    private PositionViewModel? _newSplitPosition = new();
 
     [XmlIgnore]
     public bool VisiblePositionSplit


### PR DESCRIPTION
`_newSplitPosition` is assigned after adding any other condition, so this crash only occurs on adding position first.