### PR TITLE
Add `Re-trigger flags on NG+` to Elden Ring

### DIFF
--- a/src/SoulSplitter/UI/EldenRing/EldenRingControl.xaml
+++ b/src/SoulSplitter/UI/EldenRing/EldenRingControl.xaml
@@ -81,11 +81,12 @@
 
                     <system:Int32 x:Key="StartAutomaticallyRow" >0</system:Int32>
                     <system:Int32 x:Key="LockTimerRow"          >1</system:Int32>
-                    <system:Int32 x:Key="SeparatorRow"          >2</system:Int32>
-                    <system:Int32 x:Key="SplitDefinitionRow"    >3</system:Int32>
-                    <system:Int32 x:Key="SplitTypeRow"          >4</system:Int32>
-                    <system:Int32 x:Key="AddRemoveSplitRow"     >5</system:Int32>
-                    <system:Int32 x:Key="SplitsTreeRow"         >6</system:Int32>
+                    <system:Int32 x:Key="RetriggerOnNGRow"      >2</system:Int32>
+                    <system:Int32 x:Key="SeparatorRow"          >3</system:Int32>
+                    <system:Int32 x:Key="SplitDefinitionRow"    >4</system:Int32>
+                    <system:Int32 x:Key="SplitTypeRow"          >5</system:Int32>
+                    <system:Int32 x:Key="AddRemoveSplitRow"     >6</system:Int32>
+                    <system:Int32 x:Key="SplitsTreeRow"         >7</system:Int32>
 
                 </ResourceDictionary>
 
@@ -121,6 +122,12 @@
             Margin="5"
             Content="Lock IGT to 0:00 (for NG+ saves)"
             IsChecked="{Binding LockIgtToZero}"/>
+
+        <CheckBox
+            Grid.Row="{StaticResource RetriggerOnNGRow}"
+            Margin="5"
+            Content="Re-trigger Flags on NG+"
+            IsChecked="{Binding RetriggerFlagsOnNGPlus}"/>
 
         <!-- row ============================================================================================================================================================================================== -->
         <Label 

--- a/src/SoulSplitter/UI/EldenRing/EldenRingViewModel.cs
+++ b/src/SoulSplitter/UI/EldenRing/EldenRingViewModel.cs
@@ -45,6 +45,13 @@ public class EldenRingViewModel : ICustomNotifyPropertyChanged
     }
     private bool _lockIgtToZero;
 
+    public bool RetriggerFlagsOnNGPlus
+    {
+        get => _retriggerFlagsOnNGPlus;
+        set => this.SetField(ref _retriggerFlagsOnNGPlus, value);
+    }
+    private bool _retriggerFlagsOnNGPlus;
+
     [XmlIgnore]
     public PositionViewModel CurrentPosition
     {

--- a/tests/SoulSplitter.Tests/XmlData.cs
+++ b/tests/SoulSplitter.Tests/XmlData.cs
@@ -88,6 +88,7 @@ namespace SoulSplitter.Tests
   <EldenRingViewModel>
     <StartAutomatically>true</StartAutomatically>
     <LockIgtToZero>false</LockIgtToZero>
+    <RetriggerFlagsOnNGPlus>false</RetriggerFlagsOnNGPlus>
     <EnabledRemoveSplit>false</EnabledRemoveSplit>
     <Splits />
   </EldenRingViewModel>
@@ -121,6 +122,7 @@ namespace SoulSplitter.Tests
   <EldenRingViewModel>
     <StartAutomatically>true</StartAutomatically>
     <LockIgtToZero>false</LockIgtToZero>
+    <RetriggerFlagsOnNGPlus>false</RetriggerFlagsOnNGPlus>
     <EnabledRemoveSplit>false</EnabledRemoveSplit>
     <Splits>
       <HierarchicalTimingTypeViewModel>
@@ -385,6 +387,7 @@ namespace SoulSplitter.Tests
   <EldenRingViewModel>
     <StartAutomatically>true</StartAutomatically>
     <LockIgtToZero>false</LockIgtToZero>
+    <RetriggerFlagsOnNGPlus>false</RetriggerFlagsOnNGPlus>
     <EnabledRemoveSplit>false</EnabledRemoveSplit>
     <Splits />
   </EldenRingViewModel>
@@ -647,6 +650,7 @@ namespace SoulSplitter.Tests
   <EldenRingViewModel>
     <StartAutomatically>true</StartAutomatically>
     <LockIgtToZero>false</LockIgtToZero>
+    <RetriggerFlagsOnNGPlus>false</RetriggerFlagsOnNGPlus>
     <EnabledRemoveSplit>false</EnabledRemoveSplit>
     <Splits />
   </EldenRingViewModel>


### PR DESCRIPTION
This feature is requested from my friend running `All Achievements`, while runner has to complete NG+2 in this category.