### PR TITLE
version serialization bugfix

### DIFF
--- a/src/SoulSplitter/SoulSplitter.csproj
+++ b/src/SoulSplitter/SoulSplitter.csproj
@@ -30,8 +30,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
-        <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
+        <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
+        <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SoulSplitter/UI/MainViewModel.cs
+++ b/src/SoulSplitter/UI/MainViewModel.cs
@@ -63,9 +63,14 @@ public class MainViewModel : ICustomNotifyPropertyChanged
         ArmoredCore6ViewModel = mainViewModel.ArmoredCore6ViewModel;
         FlagTrackerViewModel = mainViewModel.FlagTrackerViewModel;
     }
-
-
-    public string Version { get; } = VersionHelper.Version.ToString();
+    public string Version
+    {
+        get { return VersionHelper.Version.ToString(); }
+        set
+        {
+            //don't do anything - this is just to make the serializer happy
+        }
+    }
 
     public Game SelectedGame
     {

--- a/src/SoulSplitter/VersionHelper.cs
+++ b/src/SoulSplitter/VersionHelper.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace SoulSplitter;
 
-internal static class VersionHelper
+public static class VersionHelper
 {
     public static Version Version
     { 

--- a/tests/SoulSplitter.Tests/SoulComponentTests.cs
+++ b/tests/SoulSplitter.Tests/SoulComponentTests.cs
@@ -53,7 +53,7 @@ namespace SoulSplitter.Tests
             
             var xml = viewModel.Serialize();
             var deserializedViewModel = MainViewModel.Deserialize(xml);
-
+            
             Assert.AreEqual(viewModel.EldenRingViewModel.StartAutomatically, deserializedViewModel.EldenRingViewModel.StartAutomatically);
             
             var vectorSize = deserializedViewModel.SekiroViewModel.SplitsViewModel.Splits.First().Children.First().Children.First().Split;
@@ -63,7 +63,26 @@ namespace SoulSplitter.Tests
             Assert.AreEqual(2.0f, ((VectorSize)vectorSize).Position.Y);
             Assert.AreEqual(3.0f, ((VectorSize)vectorSize).Position.Z);
             Assert.AreEqual(4.0f, ((VectorSize)vectorSize).Size);
-        }                                                 
+            Assert.IsTrue(xml.ToLowerInvariant().Contains("version"));
+        }
+
+        [TestMethodSta]
+        public void VersionFromXml_Should_Not_Deserialize()
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(XmlData.SekiroMigration1_1_0); //load a doc with version 1.1.0
+
+            var versionFromXml = doc.GetChildNodeByName("MainViewModel").GetChildNodeByName("Version").InnerText;
+
+            var liveSplitStateMock = new Mock<LiveSplitState>(args: [null!, null!, null!, null!, null!]);
+            var component = new SoulComponent(liveSplitStateMock.Object, shouldThrowOnInvalidInstallation: false);
+            component.SetSettings(doc);
+
+            var componentViewModel = component.MainWindow.MainViewModel;
+
+            Assert.AreEqual("1.1.0", versionFromXml);
+            Assert.AreEqual(VersionHelper.Version.ToString(), componentViewModel.Version);
+        }
 
         [TestMethodSta]
         public void SekiroMigration1_1_0Test()


### PR DESCRIPTION
Revert material design to prev. version because while it works outside of livesplit, it doesn't work from inside livesplit. Fixed a bug where the version is no longer being serialized since it has no setter, likely caused by enabling nullable reference types.