### PR TITLE
Fix mIGT patch for BB, DS3 and NR in v2.

### DIFF
--- a/src/soulmods/src/games/x64/bloodborne/mod.rs
+++ b/src/soulmods/src/games/x64/bloodborne/mod.rs
@@ -68,22 +68,20 @@ unsafe extern "win64" fn increment_igt_hook(registers: *mut Registers, _:usize)
 {
     unsafe
     {
-        let frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
-        let mut corrected_frame_delta = frame_delta;
-        corrected_frame_delta = corrected_frame_delta * 0.96f32; //scale to igt
+        let mut frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
+        frame_delta = frame_delta * 0.96f32; //scale to igt
 
         //Rather than casting, like the game does, make the behavior explicit by flooring
-        let floored_frame_delta = frame_delta.floor();
+        let mut floored_frame_delta = frame_delta.floor();
         let remainder = frame_delta - floored_frame_delta;
         IGT_BUFFER = IGT_BUFFER + remainder;
 
         if IGT_BUFFER > 1.0f32
         {
             IGT_BUFFER = IGT_BUFFER - 1f32;
-            corrected_frame_delta += 1f32;
+            floored_frame_delta += 1f32;
         }
 
-        (*registers).xmm0 = std::mem::transmute::<f32, u32>(corrected_frame_delta) as u128;
-        info!("frame delta: {} igt buffer: {} corrected frame delta: {}", frame_delta, IGT_BUFFER, corrected_frame_delta);
+        (*registers).xmm0 = std::mem::transmute::<f32, u32>(floored_frame_delta) as u128;
     }
 }

--- a/src/soulmods/src/games/x64/darksouls3/migt.rs
+++ b/src/soulmods/src/games/x64/darksouls3/migt.rs
@@ -53,22 +53,20 @@ unsafe extern "win64" fn increment_igt_hook(registers: *mut Registers, _:usize)
 {
     unsafe
     {
-        let frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
-        let mut corrected_frame_delta = frame_delta;
-        corrected_frame_delta = corrected_frame_delta * 0.96f32; //scale to IGT
+        let mut frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
+        frame_delta = frame_delta * 0.96f32; //scale to igt
 
         //Rather than casting, like the game does, make the behavior explicit by flooring
-        let floored_frame_delta = frame_delta.floor();
+        let mut floored_frame_delta = frame_delta.floor();
         let remainder = frame_delta - floored_frame_delta;
         IGT_BUFFER = IGT_BUFFER + remainder;
 
         if IGT_BUFFER > 1.0f32
         {
             IGT_BUFFER = IGT_BUFFER - 1f32;
-            corrected_frame_delta += 1f32;
+            floored_frame_delta += 1f32;
         }
 
-        (*registers).xmm0 = std::mem::transmute::<f32, u32>(corrected_frame_delta) as u128;
-        //info!("frame delta: {} igt buffer: {} corrected frame delta: {}", frame_delta, IGT_BUFFER, corrected_frame_delta);
+        (*registers).xmm0 = std::mem::transmute::<f32, u32>(floored_frame_delta) as u128;
     }
 }

--- a/src/soulmods/src/games/x64/nightreign/mod.rs
+++ b/src/soulmods/src/games/x64/nightreign/mod.rs
@@ -79,23 +79,21 @@ unsafe extern "win64" fn increment_igt_hook(registers: *mut Registers, _:usize)
 {
     unsafe
     {
-        let frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
-        let mut corrected_frame_delta = frame_delta;
-        corrected_frame_delta = corrected_frame_delta * 0.96f32; //scale to igt
+        let mut frame_delta = std::mem::transmute::<u32, f32>((*registers).xmm0 as u32);
+        frame_delta = frame_delta * 0.96f32; //scale to igt
 
         //Rather than casting, like the game does, make the behavior explicit by flooring
-        let floored_frame_delta = frame_delta.floor();
+        let mut floored_frame_delta = frame_delta.floor();
         let remainder = frame_delta - floored_frame_delta;
         IGT_BUFFER = IGT_BUFFER + remainder;
 
         if IGT_BUFFER > 1.0f32
         {
             IGT_BUFFER = IGT_BUFFER - 1f32;
-            corrected_frame_delta += 1f32;
+            floored_frame_delta += 1f32;
         }
 
-        (*registers).xmm0 = std::mem::transmute::<f32, u32>(corrected_frame_delta) as u128;
-        info!("frame delta: {} igt buffer: {} corrected frame delta: {}", frame_delta, IGT_BUFFER, corrected_frame_delta);
+        (*registers).xmm0 = std::mem::transmute::<f32, u32>(floored_frame_delta) as u128;
     }
 }
 


### PR DESCRIPTION
Fixes the mIGT patch for BB, DS3 and NR in v2. Previously, some part of the calculation didn't use the scaled frame delta value, leading to problems.