### PR TITLE
XInput hooks for SoulsTAS

### DIFF
--- a/src/soulmods/src/games/x64/eldenring.rs
+++ b/src/soulmods/src/games/x64/eldenring.rs
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{thread, time::Duration};
+use std::{thread, time::Duration, mem, ffi::c_void};
 
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
 
 use log::info;
+
+use windows::Win32::UI::Input::XboxController::*;
 
 use crate::util::GLOBAL_VERSION;
 use crate::util::Version;
@@ -39,6 +41,7 @@ static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
 static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
 static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
+static mut XINPUT_HOOK: Option<HookPoint> = None;
 
 static mut FPS_OFFSETS: FpsOffsets = FpsOffsets {
     target_frame_delta: 0x0,
@@ -62,6 +65,28 @@ pub static mut ER_FRAME_ADVANCE_ENABLED: bool = false;
 #[unsafe(no_mangle)]
 #[used]
 pub static mut ER_FRAME_RUNNING: bool = false;
+
+#[unsafe(no_mangle)]
+#[used]
+pub static mut ER_XINPUT_PATCH_ENABLED: bool = false;
+
+#[unsafe(no_mangle)]
+#[used]
+pub static mut ER_XINPUT_STATE: XINPUT_STATE = XINPUT_STATE {
+    dwPacketNumber: 0,
+    Gamepad: XINPUT_GAMEPAD {
+        wButtons: XINPUT_GAMEPAD_BUTTON_FLAGS(0),
+        bLeftTrigger: 0,
+        bRightTrigger: 0,
+        sThumbLX: 0,
+        sThumbLY: 0,
+        sThumbRX: 0,
+        sThumbRY: 0,
+    }
+};
+
+
+pub type XInputGetState = unsafe extern "system" fn(dw_user_index: u32, p_state: *mut XINPUT_STATE) -> u32;
 
 
 #[allow(unused_assignments)]
@@ -148,6 +173,15 @@ pub fn init_eldenring()
 
         // Enable frame advance patch
         FRAME_ADVANCE_HOOK = Some(Hooker::new(fn_frame_advance_address, HookType::JmpBack(frame_advance), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+
+
+        // Find XInputGetState function in XINPUT1_4.dll
+        let xinput_module = process.get_modules().iter().find(|m| m.name == "XINPUT1_4.dll").cloned().expect("Couldn't find XINPUT1_4.dll");
+        let xinput_fn_addr = xinput_module.get_exports().iter().find(|e| e.0 == "XInputGetState").expect("Couldn't find XInputGetState").1;
+        info!("XInputGetState at 0x{:x}", xinput_fn_addr);
+
+        // Hook XInputGetState
+        XINPUT_HOOK = Some(Hooker::new(xinput_fn_addr, HookType::Retn(xinput_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     }
 }
 
@@ -271,4 +305,22 @@ unsafe extern "win64" fn frame_advance(_registers: *mut Registers, _:usize)
             }
         }
     }
+}
+
+
+pub unsafe extern "win64" fn xinput_fn(registers: *mut Registers, orig_func_ptr: usize, _: usize) -> usize {
+    
+    let dw_user_index = (*registers).rcx as u32;
+    let p_state = (*registers).rdx as *mut XINPUT_STATE;
+
+    if !ER_XINPUT_PATCH_ENABLED {
+        let orig_func: XInputGetState = mem::transmute(orig_func_ptr);
+        return orig_func(dw_user_index, p_state) as usize;
+    }
+
+    (*p_state) = ER_XINPUT_STATE;
+
+    // ERROR_SUCCESS = 0x0
+    // ERROR_DEVICE_NOT_CONNECTED = 0x48F
+    return 0x0;
 }

--- a/src/soulmods/src/games/x64/nightreign/mod.rs
+++ b/src/soulmods/src/games/x64/nightreign/mod.rs
@@ -1,10 +1,10 @@
-use std::{thread, time::Duration, mem, ffi::c_void};
+use std::thread;
+use std::time::Duration;
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
 use log::info;
 
 use crate::util::GLOBAL_VERSION;
-
 
 static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
@@ -28,10 +28,8 @@ pub static mut NR_FRAME_ADVANCE_ENABLED: bool = false;
 #[used]
 pub static mut NR_FRAME_RUNNING: bool = false;
 
-
 static mut IGT_BUFFER: f32 = 0.0f32;
 static mut IGT_HOOK: Option<HookPoint> = None;
-
 
 pub fn init_nightreign()
 {

--- a/src/soulmods/src/games/x64/nightreign/mod.rs
+++ b/src/soulmods/src/games/x64/nightreign/mod.rs
@@ -1,15 +1,17 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration, mem, ffi::c_void};
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
 use log::info;
 
 use crate::util::GLOBAL_VERSION;
 
+use windows::Win32::UI::Input::XboxController::*;
+
 static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
 static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
 static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
+static mut XINPUT_HOOK: Option<HookPoint> = None;
 
 
 #[unsafe(no_mangle)]
@@ -28,8 +30,32 @@ pub static mut NR_FRAME_ADVANCE_ENABLED: bool = false;
 #[used]
 pub static mut NR_FRAME_RUNNING: bool = false;
 
+#[unsafe(no_mangle)]
+#[used]
+pub static mut NR_XINPUT_PATCH_ENABLED: bool = false;
+
+#[unsafe(no_mangle)]
+#[used]
+pub static mut NR_XINPUT_STATE: XINPUT_STATE = XINPUT_STATE {
+    dwPacketNumber: 0,
+    Gamepad: XINPUT_GAMEPAD {
+        wButtons: XINPUT_GAMEPAD_BUTTON_FLAGS(0),
+        bLeftTrigger: 0,
+        bRightTrigger: 0,
+        sThumbLX: 0,
+        sThumbLY: 0,
+        sThumbRX: 0,
+        sThumbRY: 0,
+    }
+};
+
+
 static mut IGT_BUFFER: f32 = 0.0f32;
 static mut IGT_HOOK: Option<HookPoint> = None;
+
+
+pub type XInputGetState = unsafe extern "system" fn(dw_user_index: u32, p_state: *mut XINPUT_STATE) -> u32;
+
 
 pub fn init_nightreign()
 {
@@ -72,6 +98,15 @@ pub fn init_nightreign()
 
         // Enable frame advance patch
         FRAME_ADVANCE_HOOK = Some(Hooker::new(fn_frame_advance_address, HookType::JmpBack(frame_advance), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
+
+
+        // Find XInputGetState function in XINPUT1_4.dll
+        let xinput_module = process.get_modules().iter().find(|m| m.name == "XINPUT1_4.dll").cloned().expect("Couldn't find XINPUT1_4.dll");
+        let xinput_fn_addr = xinput_module.get_exports().iter().find(|e| e.0 == "XInputGetState").expect("Couldn't find XInputGetState").1;
+        info!("XInputGetState at 0x{:x}", xinput_fn_addr);
+
+        // Hook XInputGetState
+        XINPUT_HOOK = Some(Hooker::new(xinput_fn_addr, HookType::Retn(xinput_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     }
 }
 
@@ -193,4 +228,22 @@ unsafe extern "win64" fn frame_advance(_registers: *mut Registers, _:usize)
             }
         }
     }
+}
+
+
+pub unsafe extern "win64" fn xinput_fn(registers: *mut Registers, orig_func_ptr: usize, _: usize) -> usize {
+    
+    let dw_user_index = (*registers).rcx as u32;
+    let p_state = (*registers).rdx as *mut XINPUT_STATE;
+
+    if !NR_XINPUT_PATCH_ENABLED {
+        let orig_func: XInputGetState = mem::transmute(orig_func_ptr);
+        return orig_func(dw_user_index, p_state) as usize;
+    }
+
+    (*p_state) = NR_XINPUT_STATE;
+
+    // ERROR_SUCCESS = 0x0
+    // ERROR_DEVICE_NOT_CONNECTED = 0x48F
+    return 0x0;
 }


### PR DESCRIPTION
This adds XInput hooks for DS3, Sekiro and ER, for gamepad inputs in SoulsTAS. As with the others, they are inactive by default and therefore don't interfere with normal controller inputs unless activated externally.