### PR TITLE
Remove SoulsTAS-specific patches

### DIFF
--- a/src/soulmods/Cargo.toml
+++ b/src/soulmods/Cargo.toml
@@ -11,7 +11,6 @@ license-file = "../../LICENSE"
 crate-type = ["cdylib"]
 
 [dependencies]
-ilhook = "2.1.2"
 iced-x86 = { version = "1.21.0", features = ["code_asm"] }
 
 mem-rs = "= 0.2.3"
@@ -21,6 +20,16 @@ lazy_static = "1.4.0"
 log = "0.4.21"
 log4rs = {version = "1.3.0", features = ["all_components" ] }
 rand = "0.9.2"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies.ilhook]
+version = "= 2.1.3"
+
+[target.'cfg(target_arch = "x86")'.dependencies.ilhook]
+version = "= 2.1.3"
+default-features = false
+features = [
+    "x86"
+]
 
 [dependencies.windows]
 version = "0.61.3"

--- a/src/soulmods/Cargo.toml
+++ b/src/soulmods/Cargo.toml
@@ -11,6 +11,7 @@ license-file = "../../LICENSE"
 crate-type = ["cdylib"]
 
 [dependencies]
+ilhook = "2.1.2"
 iced-x86 = { version = "1.21.0", features = ["code_asm"] }
 
 mem-rs = "= 0.2.3"
@@ -20,16 +21,6 @@ lazy_static = "1.4.0"
 log = "0.4.21"
 log4rs = {version = "1.3.0", features = ["all_components" ] }
 rand = "0.9.2"
-
-[target.'cfg(target_arch = "x86_64")'.dependencies.ilhook]
-version = "= 2.1.3"
-
-[target.'cfg(target_arch = "x86")'.dependencies.ilhook]
-version = "= 2.1.3"
-default-features = false
-features = [
-    "x86"
-]
 
 [dependencies.windows]
 version = "0.61.3"

--- a/src/soulmods/src/games/x64/darksouls3/mod.rs
+++ b/src/soulmods/src/games/x64/darksouls3/mod.rs
@@ -15,26 +15,22 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod migt;
-pub use migt::increment_igt_hook;
-pub(crate) use migt::IGT_BUFFER;
 
 
 #[allow(dead_code)]
 
 use mem_rs::prelude::*;
-use std::{thread, time::Duration, mem};
+use std::{thread, time::Duration};
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 
 use log::info;
 use crate::games::x64::darksouls3::migt::ds3_init_migt;
 use crate::util::*;
 
-use windows::Win32::UI::Input::XboxController::*;
 
 static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
 static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
-static mut XINPUT_HOOK: Option<HookPoint> = None;
 
 
 #[unsafe(no_mangle)]
@@ -52,28 +48,6 @@ pub static mut DS3_FRAME_ADVANCE_ENABLED: bool = false;
 #[unsafe(no_mangle)]
 #[used]
 pub static mut DS3_FRAME_RUNNING: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut DS3_XINPUT_PATCH_ENABLED: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut DS3_XINPUT_STATE: XINPUT_STATE = XINPUT_STATE {
-    dwPacketNumber: 0,
-    Gamepad: XINPUT_GAMEPAD {
-        wButtons: XINPUT_GAMEPAD_BUTTON_FLAGS(0),
-        bLeftTrigger: 0,
-        bRightTrigger: 0,
-        sThumbLX: 0,
-        sThumbLY: 0,
-        sThumbRX: 0,
-        sThumbRY: 0,
-    }
-};
-
-
-pub type XInputGetState = unsafe extern "system" fn(dw_user_index: u32, p_state: *mut XINPUT_STATE) -> u32;
 
 
 #[allow(unused_assignments)]
@@ -124,15 +98,6 @@ pub fn init_darksouls3()
 
         // Turn off frame-advance again..
         DS3_FRAME_ADVANCE_ENABLED = false;
-
-
-        // Find XInputGetState function in XINPUT1_3.dll
-        let xinput_module = process.get_modules().iter().find(|m| m.name == "XINPUT1_3.dll").cloned().expect("Couldn't find XINPUT1_3.dll");
-        let xinput_fn_addr = xinput_module.get_exports().iter().find(|e| e.0 == "XInputGetState").expect("Couldn't find XInputGetState").1;
-        info!("XInputGetState at 0x{:x}", xinput_fn_addr);
-
-        // Hook XInputGetState
-        XINPUT_HOOK = Some(Hooker::new(xinput_fn_addr, HookType::Retn(xinput_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     }
 }
 
@@ -267,21 +232,3 @@ unsafe extern "win64" fn frame_advance(_registers: *mut Registers, _:usize)
         }
     }
 }
-
-
-pub unsafe extern "win64" fn xinput_fn(registers: *mut Registers, orig_func_ptr: usize, _: usize) -> usize { unsafe {
-    
-    let dw_user_index = (*registers).rcx as u32;
-    let p_state = (*registers).rdx as *mut XINPUT_STATE;
-
-    if !DS3_XINPUT_PATCH_ENABLED {
-        let orig_func: XInputGetState = mem::transmute(orig_func_ptr);
-        return orig_func(dw_user_index, p_state) as usize;
-    }
-
-    (*p_state) = DS3_XINPUT_STATE;
-
-    // ERROR_SUCCESS = 0x0
-    // ERROR_DEVICE_NOT_CONNECTED = 0x48F
-    return 0x0;
-}}

--- a/src/soulmods/src/games/x64/eldenring.rs
+++ b/src/soulmods/src/games/x64/eldenring.rs
@@ -14,17 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{thread, time::Duration, mem};
-
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
 
 use log::info;
 
-use windows::Win32::UI::Input::XboxController::*;
-
 use crate::util::GLOBAL_VERSION;
 use crate::util::Version;
+
 
 struct FpsOffsets
 {
@@ -34,14 +31,13 @@ struct FpsOffsets
     timestamp_current: isize,
 }
 
+
 pub(crate) static mut IGT_BUFFER: f32 = 0.0f32;
 static mut IGT_HOOK: Option<HookPoint> = None;
 
 static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
 static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
-static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
-static mut XINPUT_HOOK: Option<HookPoint> = None;
 
 static mut FPS_OFFSETS: FpsOffsets = FpsOffsets {
     target_frame_delta: 0x0,
@@ -50,6 +46,7 @@ static mut FPS_OFFSETS: FpsOffsets = FpsOffsets {
     timestamp_current: 0x0,
 };
 
+
 #[unsafe(no_mangle)]
 #[used]
 pub static mut ER_FPS_PATCH_ENABLED: bool = false;
@@ -57,36 +54,6 @@ pub static mut ER_FPS_PATCH_ENABLED: bool = false;
 #[unsafe(no_mangle)]
 #[used]
 pub static mut ER_FPS_CUSTOM_LIMIT: f32 = 0.0f32;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut ER_FRAME_ADVANCE_ENABLED: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut ER_FRAME_RUNNING: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut ER_XINPUT_PATCH_ENABLED: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut ER_XINPUT_STATE: XINPUT_STATE = XINPUT_STATE {
-    dwPacketNumber: 0,
-    Gamepad: XINPUT_GAMEPAD {
-        wButtons: XINPUT_GAMEPAD_BUTTON_FLAGS(0),
-        bLeftTrigger: 0,
-        bRightTrigger: 0,
-        sThumbLX: 0,
-        sThumbLY: 0,
-        sThumbRX: 0,
-        sThumbRY: 0,
-    }
-};
-
-
-pub type XInputGetState = unsafe extern "system" fn(dw_user_index: u32, p_state: *mut XINPUT_STATE) -> u32;
 
 
 #[allow(unused_assignments)]
@@ -165,23 +132,6 @@ pub fn init_eldenring()
 
         // Enable FPS custom limit patch
         FPS_CUSTOM_LIMIT_HOOK = Some(Hooker::new(fn_fps_custom_limit_address, HookType::JmpBack(fps_custom_limit), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
-    
-
-        // AoB scan for frame advance patch
-        let fn_frame_advance_address = process.scan_abs("frame_advance", "e8 ? ? ? ? e8 ? ? ? ? 84 c0 74 4f", 21, Vec::new()).unwrap().get_base_address();
-        info!("Frame advance at 0x{:x}", fn_frame_advance_address);
-
-        // Enable frame advance patch
-        FRAME_ADVANCE_HOOK = Some(Hooker::new(fn_frame_advance_address, HookType::JmpBack(frame_advance), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
-
-
-        // Find XInputGetState function in XINPUT1_4.dll
-        let xinput_module = process.get_modules().iter().find(|m| m.name == "XINPUT1_4.dll").cloned().expect("Couldn't find XINPUT1_4.dll");
-        let xinput_fn_addr = xinput_module.get_exports().iter().find(|e| e.0 == "XInputGetState").expect("Couldn't find XInputGetState").1;
-        info!("XInputGetState at 0x{:x}", xinput_fn_addr);
-
-        // Hook XInputGetState
-        XINPUT_HOOK = Some(Hooker::new(xinput_fn_addr, HookType::Retn(xinput_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     }
 }
 
@@ -290,37 +240,3 @@ unsafe extern "win64" fn fps_custom_limit(registers: *mut Registers, _:usize)
         }
     }
 }
-
-// Frame advance patch
-unsafe extern "win64" fn frame_advance(_registers: *mut Registers, _:usize)
-{
-    unsafe
-    {
-        if ER_FRAME_ADVANCE_ENABLED
-        {
-            ER_FRAME_RUNNING = false;
-
-            while !ER_FRAME_RUNNING && ER_FRAME_ADVANCE_ENABLED {
-                thread::sleep(Duration::from_micros(10));
-            }
-        }
-    }
-}
-
-
-pub unsafe extern "win64" fn xinput_fn(registers: *mut Registers, orig_func_ptr: usize, _: usize) -> usize { unsafe {
-    
-    let dw_user_index = (*registers).rcx as u32;
-    let p_state = (*registers).rdx as *mut XINPUT_STATE;
-
-    if !ER_XINPUT_PATCH_ENABLED {
-        let orig_func: XInputGetState = mem::transmute(orig_func_ptr);
-        return orig_func(dw_user_index, p_state) as usize;
-    }
-
-    (*p_state) = ER_XINPUT_STATE;
-
-    // ERROR_SUCCESS = 0x0
-    // ERROR_DEVICE_NOT_CONNECTED = 0x48F
-    return 0x0;
-}}

--- a/src/soulmods/src/games/x64/nightreign.rs
+++ b/src/soulmods/src/games/x64/nightreign.rs
@@ -1,15 +1,13 @@
-use std::thread;
-use std::time::Duration;
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
 use log::info;
 
 use crate::util::GLOBAL_VERSION;
 
+
 static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
 static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
-static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
 
 
 #[unsafe(no_mangle)]
@@ -20,16 +18,10 @@ pub static mut NR_FPS_PATCH_ENABLED: bool = false;
 #[used]
 pub static mut NR_FPS_CUSTOM_LIMIT: f32 = 0.0f32;
 
-#[unsafe(no_mangle)]
-#[used]
-pub static mut NR_FRAME_ADVANCE_ENABLED: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut NR_FRAME_RUNNING: bool = false;
 
 pub(crate) static mut IGT_BUFFER: f32 = 0.0f32;
 static mut IGT_HOOK: Option<HookPoint> = None;
+
 
 pub fn init_nightreign()
 {
@@ -64,14 +56,6 @@ pub fn init_nightreign()
 
         // Enable FPS custom limit patch
         FPS_CUSTOM_LIMIT_HOOK = Some(Hooker::new(fn_fps_custom_limit_address, HookType::JmpBack(fps_custom_limit), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
-
-
-        // AoB scan for frame advance patch
-        let fn_frame_advance_address = process.scan_abs("frame_advance", "e8 ? ? ? ? e8 ? ? ? ? 84 c0 74 4f", 21, Vec::new()).unwrap().get_base_address();
-        info!("Frame advance at 0x{:x}", fn_frame_advance_address);
-
-        // Enable frame advance patch
-        FRAME_ADVANCE_HOOK = Some(Hooker::new(fn_frame_advance_address, HookType::JmpBack(frame_advance), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     }
 }
 
@@ -174,22 +158,6 @@ unsafe extern "win64" fn fps_custom_limit(registers: *mut Registers, _:usize)
             {
                 // Write values back
                 std::ptr::write_volatile(ptr_target_frame_delta, custom_target_frame_delta);
-            }
-        }
-    }
-}
-
-// Frame advance patch
-unsafe extern "win64" fn frame_advance(_registers: *mut Registers, _:usize)
-{
-    unsafe
-    {
-        if NR_FRAME_ADVANCE_ENABLED
-        {
-            NR_FRAME_RUNNING = false;
-
-            while !NR_FRAME_RUNNING && NR_FRAME_ADVANCE_ENABLED {
-                thread::sleep(Duration::from_micros(10));
             }
         }
     }

--- a/src/soulmods/src/games/x64/sekiro.rs
+++ b/src/soulmods/src/games/x64/sekiro.rs
@@ -14,26 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
-
-use std::{ptr, thread, time::Duration, mem};
+use std::ptr;
 
 use ilhook::x64::{Hooker, HookType, Registers, CallbackOption, HookFlags, HookPoint};
 use mem_rs::prelude::*;
 
 use log::info;
 
-use windows::Win32::UI::Input::XboxController::*;
-
 use crate::util::GLOBAL_VERSION;
+
 
 static mut IGT_HOOK: Option<HookPoint> = None;
 static mut FPS_HOOK: Option<HookPoint> = None;
 static mut FPS_HISTORY_HOOK: Option<HookPoint> = None;
 static mut FPS_CUSTOM_LIMIT_HOOK: Option<HookPoint> = None;
-static mut FRAME_ADVANCE_HOOK: Option<HookPoint> = None;
 static mut EMEVD_EVENT_HOOK: Option<HookPoint> = None;
-static mut XINPUT_HOOK: Option<HookPoint> = None;
+
 
 #[allow(dead_code)]
 static mut HANDLE_FADE_HOOK: Option<HookPoint> = None;
@@ -46,40 +42,10 @@ pub static mut SEKIRO_FPS_PATCH_ENABLED: bool = false;
 #[used]
 pub static mut SEKIRO_FPS_CUSTOM_LIMIT: f32 = 0.0f32;
 
-#[unsafe(no_mangle)]
-#[used]
-pub static mut SEKIRO_FRAME_ADVANCE_ENABLED: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut SEKIRO_FRAME_RUNNING: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut SEKIRO_XINPUT_PATCH_ENABLED: bool = false;
-
-#[unsafe(no_mangle)]
-#[used]
-pub static mut SEKIRO_XINPUT_STATE: XINPUT_STATE = XINPUT_STATE {
-    dwPacketNumber: 0,
-    Gamepad: XINPUT_GAMEPAD {
-        wButtons: XINPUT_GAMEPAD_BUTTON_FLAGS(0),
-        bLeftTrigger: 0,
-        bRightTrigger: 0,
-        sThumbLX: 0,
-        sThumbLY: 0,
-        sThumbRX: 0,
-        sThumbRY: 0,
-    }
-};
-
 
 pub static mut IGT_BUFFER: f32 = 0.0f32;
 
 pub static mut FADE_MAN_ADDRESS: usize = 0usize;
-
-
-pub type XInputGetState = unsafe extern "system" fn(dw_user_index: u32, p_state: *mut XINPUT_STATE) -> u32;
 
 
 #[allow(unused_assignments)]
@@ -124,27 +90,11 @@ pub fn init_sekiro()
         FPS_CUSTOM_LIMIT_HOOK = Some(Hooker::new(fn_fps_custom_limit_address, HookType::JmpBack(fps_custom_limit), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     
 
-        // AoB scan for frame advance patch
-        let fn_frame_advance_address = process.scan_abs("frame_advance", "e8 ? ? ? ? 84 c0 74 4e 66 0f 1f 44 00 00", 15, Vec::new()).unwrap().get_base_address();
-        info!("Frame advance at 0x{:x}", fn_frame_advance_address);
-
-        // Enable frame advance patch
-        FRAME_ADVANCE_HOOK = Some(Hooker::new(fn_frame_advance_address, HookType::JmpBack(frame_advance), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
-
         let emevd_events_address = process.scan_abs("emevd_events", "24 20 fe ff ff ff 0f 29 b4 24 30 01 00 00", 0, Vec::new()).unwrap().get_base_address() - 14;
         info!("emevd at 0x{:x}", emevd_events_address);
         EMEVD_EVENT_HOOK = Some(Hooker::new(emevd_events_address, HookType::JmpBack(emevd_event_hook_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
 
         //HANDLE_FADE_HOOK = Some(Hooker::new(0x140f26ed0, HookType::JmpBack(handle_fade_hook_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
-
-
-        // Find XInputGetState function in XINPUT1_3.dll
-        let xinput_module = process.get_modules().iter().find(|m| m.name == "XINPUT1_3.dll").cloned().expect("Couldn't find XINPUT1_3.dll");
-        let xinput_fn_addr = xinput_module.get_exports().iter().find(|e| e.0 == "XInputGetState").expect("Couldn't find XInputGetState").1;
-        info!("XInputGetState at 0x{:x}", xinput_fn_addr);
-
-        // Hook XInputGetState
-        XINPUT_HOOK = Some(Hooker::new(xinput_fn_addr, HookType::Retn(xinput_fn), CallbackOption::None, 0, HookFlags::empty()).hook().unwrap());
     }
 }
 
@@ -288,22 +238,6 @@ unsafe extern "win64" fn fps_custom_limit(registers: *mut Registers, _:usize)
     }
 }
 
-// Frame advance patch
-unsafe extern "win64" fn frame_advance(_registers: *mut Registers, _:usize)
-{
-    unsafe
-    {
-        if SEKIRO_FRAME_ADVANCE_ENABLED
-        {
-            SEKIRO_FRAME_RUNNING = false;
-
-            while !SEKIRO_FRAME_RUNNING && SEKIRO_FRAME_ADVANCE_ENABLED {
-                thread::sleep(Duration::from_micros(10));
-            }
-        }
-    }
-}
-
 
 #[unsafe(no_mangle)]
 #[used]
@@ -353,21 +287,3 @@ unsafe extern "win64" fn emevd_event_hook_fn(registers: *mut Registers, _:usize)
         }
     }
 }
-
-
-pub unsafe extern "win64" fn xinput_fn(registers: *mut Registers, orig_func_ptr: usize, _: usize) -> usize { unsafe {
-    
-    let dw_user_index = (*registers).rcx as u32;
-    let p_state = (*registers).rdx as *mut XINPUT_STATE;
-
-    if !SEKIRO_XINPUT_PATCH_ENABLED {
-        let orig_func: XInputGetState = mem::transmute(orig_func_ptr);
-        return orig_func(dw_user_index, p_state) as usize;
-    }
-
-    (*p_state) = SEKIRO_XINPUT_STATE;
-
-    // ERROR_SUCCESS = 0x0
-    // ERROR_DEVICE_NOT_CONNECTED = 0x48F
-    return 0x0;
-}}


### PR DESCRIPTION
This removes SoulsTAS-specific patches from soulmods, since they've been moved to a separate DLL here: https://github.com/Vinjul1704/SoulsTAS/commit/54e07bbf90a4f56abccc9540cfcee35a7ffef6a6

FPS patches remain in soulmods, as well as the frame-advance patch for DS3 specifically, since that's required for the current Arxan workaround.